### PR TITLE
Bump aws sdk version to the minimum version compatible with IMDSv2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ dependencies {
     compileOnly "org.immutables:value:2.5.6"
     implementation "com.google.guava:guava:23.0"
     implementation "com.amazonaws:aws-java-sdk-dynamodb:1.11.678"
-    implementation "com.amazonaws:aws-java-sdk-sts:1.11.678"
 
     compileOnly "org.apache.hadoop:hadoop-common:3.1.2"
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'jacoco'
     id 'maven-publish'
     id 'signing'
-    id 'com.github.johnrengelman.shadow' version '2.0.4'
+    id 'com.github.johnrengelman.shadow' version '7.1.2'
 }
 
 repositories {
@@ -25,7 +25,8 @@ dependencies {
     annotationProcessor "org.immutables:value:2.5.6"
     compileOnly "org.immutables:value:2.5.6"
     implementation "com.google.guava:guava:23.0"
-    implementation "com.amazonaws:aws-java-sdk-dynamodb:1.11.665"
+    implementation "com.amazonaws:aws-java-sdk-dynamodb:1.11.678"
+    implementation "com.amazonaws:aws-java-sdk-sts:1.11.678"
 
     compileOnly "org.apache.hadoop:hadoop-common:3.1.2"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Bump the AWS SDK 1.x version to the minimum version that support using IMDSv2. The com.github.johnrengelman.shadow plugin has also been upgraded, as errors during the local build arose. 

## Related Issue

## Motivation and Context

Upgrading from Amazon EMR 5.36 to EMR 7.10 means that the newer EC2 instances are using IMDSv2 instead of v1.

We encountered the following error:
Unable to find a region via the region provider chain. Must provide an explicit region in the builder or setup environment to supply a region.

The newer version of the sdk does not pose a great risk and it fixes the IMDS compatibility issue.

## How Has This Been Tested?

I built the project locally and used the new JAR. The error is not showing up anymore and everything works just fine.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
